### PR TITLE
Csv 파싱 및 클래스 생성 자동화 기능 추가

### DIFF
--- a/Union/Assets/Resources/Csv.meta
+++ b/Union/Assets/Resources/Csv.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22b330b78fcb8443fa9f00a9682220c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Resources/Csv/EnemyInformation.csv
+++ b/Union/Assets/Resources/Csv/EnemyInformation.csv
@@ -1,0 +1,2 @@
+﻿infoID,name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+1001,Test_enemy_01,20,10,10,10,20,10

--- a/Union/Assets/Resources/Csv/EnemyInformation.csv
+++ b/Union/Assets/Resources/Csv/EnemyInformation.csv
@@ -1,2 +1,4 @@
-﻿infoID,name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+﻿InfoID,Name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+int,string,int,int,int,int,int,int
 1001,Test_enemy_01,20,10,10,10,20,10
+1002,Test_enemy_02,21,11,11,11,21,11

--- a/Union/Assets/Resources/Csv/EnemyInformation.csv.meta
+++ b/Union/Assets/Resources/Csv/EnemyInformation.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f35c03d184c734c07a31634940d47c58
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Resources/Csv/PlayerInformation.csv
+++ b/Union/Assets/Resources/Csv/PlayerInformation.csv
@@ -1,0 +1,2 @@
+﻿infoID,name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+1001,Test_Player_01,100,10,10,10,20,10

--- a/Union/Assets/Resources/Csv/PlayerInformation.csv
+++ b/Union/Assets/Resources/Csv/PlayerInformation.csv
@@ -1,2 +1,4 @@
-﻿infoID,name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+﻿InfoID,Name,HealthPoint,PhysicalPower,PhysicalDefense,WalkingSpeed,RunningSpeed,JumpingPower
+int,string,int,int,int,int,int,int
 1001,Test_Player_01,100,10,10,10,20,10
+1002,Test_Player_02,101,11,11,11,21,11

--- a/Union/Assets/Resources/Csv/PlayerInformation.csv.meta
+++ b/Union/Assets/Resources/Csv/PlayerInformation.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec09fcbc622ee4c56aa224129e45f4da
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv.meta
+++ b/Union/Assets/Scripts/Util/Csv.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 684b0abbab7754d7299336d00ba50a58
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/Class.meta
+++ b/Union/Assets/Scripts/Util/Csv/Class.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3df2e0692786c46719662e3d511f1b79
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs
+++ b/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs
@@ -1,0 +1,15 @@
+namespace Union.Util.Csv
+{
+    public class EnemyInformation
+    {
+        public int InfoID { get; set; }
+        public string Name { get; set; }
+        public int HealthPoint { get; set; }
+        public int PhysicalPower { get; set; }
+        public int PhysicalDefense { get; set; }
+        public int WalkingSpeed { get; set; }
+        public int RunningSpeed { get; set; }
+        public int JumpingPower { get; set; }
+    }
+
+}

--- a/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs
+++ b/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs
@@ -1,6 +1,6 @@
 namespace Union.Util.Csv
 {
-    public class EnemyInformation
+    public class EnemyInformation : IData
     {
         public int InfoID { get; set; }
         public string Name { get; set; }

--- a/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs.meta
+++ b/Union/Assets/Scripts/Util/Csv/Class/EnemyInformation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e04dc9a19066d4389a86c0576d24077f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs
+++ b/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs
@@ -1,0 +1,15 @@
+namespace Union.Util.Csv
+{
+    public class PlayerInformation
+    {
+        public int InfoID { get; set; }
+        public string Name { get; set; }
+        public int HealthPoint { get; set; }
+        public int PhysicalPower { get; set; }
+        public int PhysicalDefense { get; set; }
+        public int WalkingSpeed { get; set; }
+        public int RunningSpeed { get; set; }
+        public int JumpingPower { get; set; }
+    }
+
+}

--- a/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs
+++ b/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs
@@ -1,6 +1,6 @@
 namespace Union.Util.Csv
 {
-    public class PlayerInformation
+    public class PlayerInformation : IData
     {
         public int InfoID { get; set; }
         public string Name { get; set; }

--- a/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs.meta
+++ b/Union/Assets/Scripts/Util/Csv/Class/PlayerInformation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73f63cdf55c1746a7aff22c39a70190d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/ClassMaker.cs
+++ b/Union/Assets/Scripts/Util/Csv/ClassMaker.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using UnityEngine;
+using UnityEditor;
+
+namespace Union.Util.Csv
+{
+    public class ClassMaker
+    {
+        [MenuItem("Csv/Refresh All Csv Class from Csv Files")]
+        private static void RefreshAllCsvClass()
+        {
+            ClassMaker classMaker = new ClassMaker();
+
+            List<string> csvPaths = classMaker.FindCsvPaths();
+            foreach (string csvPath in csvPaths)
+            {
+                classMaker.CreateCsvClass(csvPath);
+            }
+
+            AssetDatabase.Refresh();
+        }
+
+        public void CreateCsvClass(string csvPath)
+        {
+            string assetCsvPath = csvPath;
+            assetCsvPath = assetCsvPath.Replace("Assets/Resources/", "");
+            assetCsvPath = assetCsvPath.Replace(".csv", "");
+
+            TextAsset data = Resources.Load(assetCsvPath) as TextAsset;
+
+            const string LineSplitChars = @"\r\n|\n\r|\n|\r";
+            var lines = Regex.Split(data.text, LineSplitChars);
+            if (lines.Length <= Constants.MinimumLineLengthOfCsv)
+            {
+                Debug.LogError("error : " + csvPath + " line 길이 에러");
+                return;
+            }
+
+            StringBuilder classStringBuilder = new StringBuilder();
+            string csvName = GetCsvName(csvPath);
+
+            // Begin
+            classStringBuilder.AppendLine("namespace Union.Util.Csv");
+            classStringBuilder.AppendLine("{");
+            classStringBuilder.AppendLine($"    public class {csvName}");
+            classStringBuilder.AppendLine("    {");
+
+            // Variables
+            const string SplitChars = @",(?=(?:[^""]*""[^""]*"")*(?![^""]*""))";
+            char[] trimChars = { '\"' };
+            string[] variableNames = Regex.Split(lines[0], SplitChars);
+            string[] dataTypes = Regex.Split(lines[1], SplitChars);
+            for (uint i = 0; i < variableNames.Length && i < dataTypes.Length; i++)
+            {
+                string dataType = dataTypes[i];
+                dataType = dataType.TrimStart(trimChars).TrimEnd(trimChars).Replace("\\", "");
+                dataType = dataType.Replace("<br>", "\n");
+                dataType = dataType.Replace("<c>", ",");
+
+                classStringBuilder.AppendLine($"        public {dataType} {variableNames[i]} {{ get; set; }}");
+            }
+
+            // End
+            classStringBuilder.AppendLine("    }");
+            classStringBuilder.AppendLine();
+            classStringBuilder.AppendLine("}");
+
+            string csvClassDirectoryPath = Application.dataPath + "/Scripts/Util/Csv/Class";
+            CheckAndCreateCsvClassDirectory(csvClassDirectoryPath);
+
+            string writePath = csvClassDirectoryPath + $"/{csvName}.cs";
+            File.WriteAllText(writePath, classStringBuilder.ToString());
+        }
+
+        private void CheckAndCreateCsvClassDirectory(string csvClassDirectoryPath)
+        {
+            DirectoryInfo directoryInfo = new DirectoryInfo(csvClassDirectoryPath);
+
+            if (directoryInfo.Exists == false)
+            {
+                directoryInfo.Create();
+            }
+        }
+
+        private string GetCsvName(string csvPath)
+        {
+            int lastIndexOfSlash = csvPath.LastIndexOf("/") + 1;
+            int lastIndexOfCsv = csvPath.LastIndexOf(".csv");
+            string csvName = csvPath.Substring(lastIndexOfSlash, lastIndexOfCsv - lastIndexOfSlash);
+
+            return csvName;
+        }
+
+        public List<string> FindCsvPaths()
+        {
+            List<string> csvPaths = new List<string>();
+            string[] filePaths = { "" };
+
+            try
+            {
+                const string CsvDirectoryPath = "Assets/Resources/Csv";
+                filePaths = Directory.GetFiles(CsvDirectoryPath, "*.*", SearchOption.AllDirectories);
+            }
+            catch (IOException ex) 
+            {
+                Debug.Log(ex.Message);
+            }
+
+            foreach (string filePath in filePaths)
+            {
+                if (IsCsvFile(filePath) == true)
+                {
+                    csvPaths.Add(filePath);
+                }
+            }
+
+            return csvPaths;
+        }
+
+        private bool IsCsvFile(string file)
+        {
+            return file.EndsWith(".csv");
+        }
+
+    }
+}

--- a/Union/Assets/Scripts/Util/Csv/ClassMaker.cs.meta
+++ b/Union/Assets/Scripts/Util/Csv/ClassMaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88c01d426051c46c7be84e7c40a3e048
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/IData.cs
+++ b/Union/Assets/Scripts/Util/Csv/IData.cs
@@ -1,0 +1,7 @@
+namespace Union.Util.Csv
+{
+    public interface IData
+    {
+
+    }
+}

--- a/Union/Assets/Scripts/Util/Csv/IData.cs.meta
+++ b/Union/Assets/Scripts/Util/Csv/IData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 275756bad4b0dde4ca9d18afe215a362
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace Union.Util.Csv
+{
+    public class Reader
+    {
+        private static class Constants
+        {
+            public const string BaseCsvPath = "Csv/";
+
+            public const string SplitChars = @",(?=(?:[^""]*""[^""]*"")*(?![^""]*""))";
+            public const string LineSplitChars = @"\r\n|\n\r|\n|\r";
+            public static char[] TrimChars = { '\"' };
+        }
+
+        private string _csvPath;
+        private List<Dictionary<string, string>> _data;
+
+        public Reader(string csvPath)
+        {
+            this._csvPath = csvPath;
+        }
+
+        public void Read()
+        {
+            string fullCsvPath = Constants.BaseCsvPath + this._csvPath;
+            TextAsset data = Resources.Load(fullCsvPath) as TextAsset;
+            var lines = Regex.Split(data.text, Constants.LineSplitChars);
+
+            if (lines.Length <= 1)
+            {
+                Debug.LogError("error : " + fullCsvPath + " line 길이 에러");
+                return;
+            }
+
+            this._data = new List<Dictionary<string, string>>();
+
+            var header = Regex.Split(lines[0], Constants.SplitChars);
+            for (var i = 1; i < lines.Length; i++)
+            {
+                var values = Regex.Split(lines[i], Constants.SplitChars);
+
+                if (values.Length == 0 || values[0] == "")
+                {
+                    continue;
+                }
+
+                var entry = new Dictionary<string, string>();
+                for (var j = 0; j < header.Length && j < values.Length; j++)
+                {
+                    string value = values[j];
+                    value = value.TrimStart(Constants.TrimChars).TrimEnd(Constants.TrimChars).Replace("\\", "");
+                    value = value.Replace("<br>", "\n");
+                    value = value.Replace("<c>", ",");
+
+                    entry[header[j]] = value;
+                }
+
+                this._data.Add(entry);
+            }
+        }
+
+        public int GetInfoID(int index)
+        {
+            return int.Parse(this._data[index]["infoID"]);
+        }
+
+        public T GetData<T>(string key, int infoID)
+        {
+            Dictionary<string, string> data = FindData(infoID);
+
+            if (data == null)
+                return default(T);
+
+            return (T)Convert.ChangeType(data[key].ToString(), typeof(T));
+        }
+
+        public List<T> GetDataList<T>(string key, int infoID)
+        {
+            Dictionary<string, string> data = FindData(infoID);
+
+            if (data == null)
+                return null;
+
+            string[] trimmedData = data[key].Trim('[', ']').Split(',');
+            List<T> result = new List<T>();
+
+            for (int i = 0; i < trimmedData.Length; i++)
+            {
+                result.Add((T)Convert.ChangeType(trimmedData[i], typeof(T)));
+            }
+
+            return result;
+        }
+
+        private Dictionary<string, string> FindData(int infoID)
+        {
+            string id = infoID.ToString();
+
+            for (int i = 0; i < this._data.Count; i++)
+            {
+                if (this._data[i]["infoID"] != id)
+                {
+                    continue;
+                }
+
+                return this._data[i];
+            }
+
+            return null;
+        }
+    }
+}

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -41,7 +41,7 @@ namespace Union.Util.Csv
         private void Read()
         {
             string csvPath = this._csvPath;
-            TextAsset data = Resources.Load(csvPath) as TextAsset;
+            TextAsset data = Resources.Load<TextAsset>(csvPath);
 
             const string LineSplitChars = @"\r\n|\n\r|\n|\r";
             string[] csvRows = Regex.Split(data.text, LineSplitChars);

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -8,15 +8,6 @@ namespace Union.Util.Csv
 {
     public class Reader
     {
-        private static class Constants
-        {
-            public const string BaseCsvPath = "Csv/";
-
-            public const string SplitChars = @",(?=(?:[^""]*""[^""]*"")*(?![^""]*""))";
-            public const string LineSplitChars = @"\r\n|\n\r|\n|\r";
-            public static char[] TrimChars = { '\"' };
-        }
-
         private string _csvPath;
         private List<Dictionary<string, string>> _data;
 
@@ -27,9 +18,12 @@ namespace Union.Util.Csv
 
         public void Read()
         {
-            string fullCsvPath = Constants.BaseCsvPath + this._csvPath;
+            const string BaseCsvPath = "Csv/";
+            const string LineSplitChars = @"\r\n|\n\r|\n|\r";
+
+            string fullCsvPath = BaseCsvPath + this._csvPath;
             TextAsset data = Resources.Load(fullCsvPath) as TextAsset;
-            var lines = Regex.Split(data.text, Constants.LineSplitChars);
+            var lines = Regex.Split(data.text, LineSplitChars);
 
             if (lines.Length <= 1)
             {
@@ -39,10 +33,12 @@ namespace Union.Util.Csv
 
             this._data = new List<Dictionary<string, string>>();
 
-            var header = Regex.Split(lines[0], Constants.SplitChars);
+            const string SplitChars = @",(?=(?:[^""]*""[^""]*"")*(?![^""]*""))";
+            char[] trimChars = { '\"' };
+            var header = Regex.Split(lines[0], SplitChars);
             for (var i = 1; i < lines.Length; i++)
             {
-                var values = Regex.Split(lines[i], Constants.SplitChars);
+                var values = Regex.Split(lines[i], SplitChars);
 
                 if (values.Length == 0 || values[0] == "")
                 {
@@ -53,7 +49,7 @@ namespace Union.Util.Csv
                 for (var j = 0; j < header.Length && j < values.Length; j++)
                 {
                     string value = values[j];
-                    value = value.TrimStart(Constants.TrimChars).TrimEnd(Constants.TrimChars).Replace("\\", "");
+                    value = value.TrimStart(trimChars).TrimEnd(trimChars).Replace("\\", "");
                     value = value.Replace("<br>", "\n");
                     value = value.Replace("<c>", ",");
 

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -11,7 +11,7 @@ namespace Union.Util.Csv
         public const int MinimumLineLengthOfCsv = 2;
     }
 
-    public class Reader <T> where T : class
+    public class Reader <T> where T : IData
     {
         private string _csvPath;
         private Dictionary<int, T> _datas;

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -71,7 +71,7 @@ namespace Union.Util.Csv
             return int.Parse(this._datas[index]["infoID"]);
         }
 
-        public T GetData<T>(string key, int infoID) where T : struct
+        public T GetData<T>(string key, int infoID)
         {
             Dictionary<string, string> data = FindData(infoID);
 

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs
@@ -9,7 +9,7 @@ namespace Union.Util.Csv
     public class Reader
     {
         private string _csvPath;
-        private List<Dictionary<string, string>> _data;
+        private List<Dictionary<string, string>> _datas;
 
         public Reader(string csvPath)
         {
@@ -19,19 +19,25 @@ namespace Union.Util.Csv
         public void Read()
         {
             const string BaseCsvPath = "Csv/";
-            const string LineSplitChars = @"\r\n|\n\r|\n|\r";
-
             string fullCsvPath = BaseCsvPath + this._csvPath;
             TextAsset data = Resources.Load(fullCsvPath) as TextAsset;
-            var lines = Regex.Split(data.text, LineSplitChars);
 
+            const string LineSplitChars = @"\r\n|\n\r|\n|\r";
+            var lines = Regex.Split(data.text, LineSplitChars);
             if (lines.Length <= 1)
             {
                 Debug.LogError("error : " + fullCsvPath + " line 길이 에러");
                 return;
             }
 
-            this._data = new List<Dictionary<string, string>>();
+            if (this._datas == null)
+            {
+                this._datas = new List<Dictionary<string, string>>();
+            }
+            else
+            {
+                this._datas.Clear();
+            }
 
             const string SplitChars = @",(?=(?:[^""]*""[^""]*"")*(?![^""]*""))";
             char[] trimChars = { '\"' };
@@ -56,16 +62,16 @@ namespace Union.Util.Csv
                     entry[header[j]] = value;
                 }
 
-                this._data.Add(entry);
+                this._datas.Add(entry);
             }
         }
 
         public int GetInfoID(int index)
         {
-            return int.Parse(this._data[index]["infoID"]);
+            return int.Parse(this._datas[index]["infoID"]);
         }
 
-        public T GetData<T>(string key, int infoID)
+        public T GetData<T>(string key, int infoID) where T : struct
         {
             Dictionary<string, string> data = FindData(infoID);
 
@@ -97,14 +103,14 @@ namespace Union.Util.Csv
         {
             string id = infoID.ToString();
 
-            for (int i = 0; i < this._data.Count; i++)
+            for (int i = 0; i < this._datas.Count; i++)
             {
-                if (this._data[i]["infoID"] != id)
+                if (this._datas[i]["infoID"] != id)
                 {
                     continue;
                 }
 
-                return this._data[i];
+                return this._datas[i];
             }
 
             return null;

--- a/Union/Assets/Scripts/Util/Csv/Reader.cs.meta
+++ b/Union/Assets/Scripts/Util/Csv/Reader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 471a85ca5edd44e668dd59e8ae13aa81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Union/UserSettings/EditorUserSettings.asset
+++ b/Union/UserSettings/EditorUserSettings.asset
@@ -6,13 +6,19 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
-      flags: 0
-    RecentlyUsedScenePath-1:
       value: 22424703114646680e0b0227036c6d39111e1c28232c3f7e38271427fb
       flags: 0
-    RecentlyUsedScenePath-2:
+    RecentlyUsedScenePath-1:
       value: 2242470311464676020a192e1131791904040c1a293a353f230a123df6f23b34eee224a6c33f32330a01ea320171253aff05471ef8021e12
+      flags: 0
+    RecentlyUsedScenePath-2:
+      value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
+      flags: 0
+    RecentlyUsedScenePath-3:
+      value: 22424703114646680e0b0227036c752538242d6439262f2434
+      flags: 0
+    RecentlyUsedScenePath-4:
+      value: 22424703114646680e0b0227036c78090303192f182d35241e2a183de7ae2136ebf32f
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650

--- a/Union/UserSettings/EditorUserSettings.asset
+++ b/Union/UserSettings/EditorUserSettings.asset
@@ -6,19 +6,13 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c6d39111e1c28232c3f7e38271427fb
-      flags: 0
-    RecentlyUsedScenePath-1:
-      value: 2242470311464676020a192e1131791904040c1a293a353f230a123df6f23b34eee224a6c33f32330a01ea320171253aff05471ef8021e12
-      flags: 0
-    RecentlyUsedScenePath-2:
       value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
       flags: 0
-    RecentlyUsedScenePath-3:
-      value: 22424703114646680e0b0227036c752538242d6439262f2434
+    RecentlyUsedScenePath-1:
+      value: 22424703114646680e0b0227036c6d39111e1c28232c3f7e38271427fb
       flags: 0
-    RecentlyUsedScenePath-4:
-      value: 22424703114646680e0b0227036c78090303192f182d35241e2a183de7ae2136ebf32f
+    RecentlyUsedScenePath-2:
+      value: 2242470311464676020a192e1131791904040c1a293a353f230a123df6f23b34eee224a6c33f32330a01ea320171253aff05471ef8021e12
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
~~1. Csv 파일은 항상 "Resrouces/Csv/" 경로 하위에 배치해야 함
2. Csv Reader를 생성하면서 하위 Csv Path를 입력함
3. Read() 진행 : 따로 둔 이유는, 데이터가 필요하거나 읽고 싶은 시점에 읽기 위해서
4. GetInfoID & GetData 를 통해 데이터 파싱~~

**수정된 버전**
**1. "Resources/Csv" 경로에 Csv 파일 생성**

![image](https://user-images.githubusercontent.com/23232376/133458293-cf73c4be-9aed-4d32-8ce7-a083b5c82c45.png)

**2. Csv 양식**
- line 1 : 데이터 정보
- line 2 : 데이터 자료형
- line 3~ : 데이터
- 
![image](https://user-images.githubusercontent.com/23232376/133458809-cfac749d-278f-4bdb-92cc-0bfeec34b622.png)

**3. 상단 메뉴 [Csv -> Refresh All Csv Class from Csv Files] 클릭**

![image](https://user-images.githubusercontent.com/23232376/133458562-ddb1fd67-d7b4-4415-821b-bb8759f8c737.png)

**4. "Scripts/Util/Csv/Class" 경로에 Csv Class 가 생성되었는지 확인**

![image](https://user-images.githubusercontent.com/23232376/133458968-3d3428e5-97ed-4e0a-8499-d2730e24062b.png)

![image](https://user-images.githubusercontent.com/23232376/133459134-c205f9f3-8fa2-4eca-8486-f845ec32241e.png)

